### PR TITLE
クロスチョップドサラダの食材データ修正

### DIFF
--- a/src/app/updates/page.tsx
+++ b/src/app/updates/page.tsx
@@ -28,6 +28,25 @@ export default function UpdatesPage() {
       <h1 className="mb-8 text-2xl font-bold">アップデート情報</h1>
 
       <div className="space-y-6">
+        {/* 2026-03-26 Update */}
+        <section className="relative border-l-2 border-primary/20 pl-6 pb-8 last:pb-0">
+            <div className="absolute -left-[9px] top-0 h-4 w-4 rounded-full bg-primary ring-4 ring-background" />
+            <div className="mb-2 flex items-center gap-2">
+                <span className="font-mono text-sm font-semibold text-muted-foreground">2026.03.26</span>
+                <span className="rounded-full bg-primary/10 px-2 py-0.5 text-xs font-medium text-primary">New</span>
+            </div>
+            <h2 className="mb-3 text-lg font-semibold">レシピデータの修正</h2>
+            <div className="prose prose-sm text-muted-foreground">
+                <ul className="list-disc pl-4 space-y-1">
+                    <li>
+                        <strong>「クロスチョップドサラダ」の食材データを修正</strong>
+                        <br />
+                        不足していたワカクサコーン×11を追加し、合計食材数を正しい値（56個）に修正しました。
+                    </li>
+                </ul>
+            </div>
+        </section>
+
         {/* 2026-02-09 Update */}
         <section className="relative border-l-2 border-primary/20 pl-6 pb-8 last:pb-0">
             <div className="absolute -left-[9px] top-0 h-4 w-4 rounded-full bg-primary ring-4 ring-background" />

--- a/src/data/constants.ts
+++ b/src/data/constants.ts
@@ -11,4 +11,4 @@ export const COOKING_CATEGORIES = [
 
 // 最終更新日時（ISO 8601形式: YYYY-MM-DDTHH:mm:ss）
 // 同日の複数回アップデートに対応するため、時間を含めて管理します
-export const LATEST_UPDATE_DATE = "2026-02-09T12:00:00";
+export const LATEST_UPDATE_DATE = "2026-03-26T12:00:00";

--- a/src/data/recipes.ts
+++ b/src/data/recipes.ts
@@ -253,12 +253,13 @@ export const recipes: Recipe[] = [
     name: "クロスチョップドサラダ",
     category: "salad",
     ingredients: [
-      { id: "egg", count: 20 },
       { id: "sausage", count: 15 },
-      { id: "tomato", count: 10 }
+      { id: "egg", count: 20 },
+      { id: "tomato", count: 10 },
+      { id: "corn", count: 11 }
     ],
     energy: 8755,
-    totalIngredients: 45
+    totalIngredients: 56
   },
   {
     id: "ヤドンテールのペッパーサラダ",


### PR DESCRIPTION
## Summary
- クロスチョップドサラダに不足していたワカクサコーン×11を追加し、totalIngredientsを45→56に修正
- アップデート情報ページに修正内容を追加

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)