### PR TITLE
レシピ追加: ごろごろねっとうサラダ

### DIFF
--- a/src/app/updates/page.tsx
+++ b/src/app/updates/page.tsx
@@ -28,12 +28,30 @@ export default function UpdatesPage() {
       <h1 className="mb-8 text-2xl font-bold">アップデート情報</h1>
 
       <div className="space-y-6">
+        {/* 2026-04-27 Update */}
+        <section className="relative border-l-2 border-primary/20 pl-6 pb-8 last:pb-0">
+            <div className="absolute -left-[9px] top-0 h-4 w-4 rounded-full bg-primary ring-4 ring-background" />
+            <div className="mb-2 flex items-center gap-2">
+                <span className="font-mono text-sm font-semibold text-muted-foreground">2026.04.27</span>
+                <span className="rounded-full bg-primary/10 px-2 py-0.5 text-xs font-medium text-primary">New</span>
+            </div>
+            <h2 className="mb-3 text-lg font-semibold">レシピデータの追加</h2>
+            <div className="prose prose-sm text-muted-foreground">
+                <ul className="list-disc pl-4 space-y-1">
+                    <li>
+                        <strong>新レシピ「ごろごろねっとうサラダ」を追加</strong>
+                        <br />
+                        サラダカテゴリに新レシピ「ごろごろねっとうサラダ」を追加しました。
+                    </li>
+                </ul>
+            </div>
+        </section>
+
         {/* 2026-03-26 Update */}
         <section className="relative border-l-2 border-primary/20 pl-6 pb-8 last:pb-0">
             <div className="absolute -left-[9px] top-0 h-4 w-4 rounded-full bg-primary ring-4 ring-background" />
             <div className="mb-2 flex items-center gap-2">
                 <span className="font-mono text-sm font-semibold text-muted-foreground">2026.03.26</span>
-                <span className="rounded-full bg-primary/10 px-2 py-0.5 text-xs font-medium text-primary">New</span>
             </div>
             <h2 className="mb-3 text-lg font-semibold">レシピデータの修正</h2>
             <div className="prose prose-sm text-muted-foreground">

--- a/src/data/constants.ts
+++ b/src/data/constants.ts
@@ -11,4 +11,4 @@ export const COOKING_CATEGORIES = [
 
 // 最終更新日時（ISO 8601形式: YYYY-MM-DDTHH:mm:ss）
 // 同日の複数回アップデートに対応するため、時間を含めて管理します
-export const LATEST_UPDATE_DATE = "2026-03-26T12:00:00";
+export const LATEST_UPDATE_DATE = "2026-04-27T12:00:00";

--- a/src/data/recipes.ts
+++ b/src/data/recipes.ts
@@ -2,6 +2,19 @@ import { Recipe } from "@/types";
 
 export const recipes: Recipe[] = [
   {
+    id: "ごろごろねっとうサラダ",
+    name: "ごろごろねっとうサラダ",
+    category: "salad",
+    ingredients: [
+      { id: "pumpkin", count: 20 },
+      { id: "potato", count: 30 },
+      { id: "corn", count: 18 },
+      { id: "mushroom", count: 27 }
+    ],
+    energy: 25356,
+    totalIngredients: 95
+  },
+  {
     id: "みつあつめチョコワッフル",
     name: "みつあつめチョコワッフル",
     category: "dessert",


### PR DESCRIPTION
## Summary
- `ごろごろねっとうサラダ`（サラダ）を recipes.ts に追加
- 食材: ずっしりカボチャ×20、ほっこりポテト×30、ワカクサコーン×18、あじわいキノコ×27
- エネルギー: 25356、合計食材数: 95

Closes #9

## Test plan
- [ ] レシピ一覧にごろごろねっとうサラダが表示される
- [ ] サラダカテゴリで正しくフィルタリングされる
- [ ] 食材サマリーに正しく反映される

🤖 Generated with [Claude Code](https://claude.com/claude-code)